### PR TITLE
bindings/go: keep futures alive on use

### DIFF
--- a/bindings/go/src/fdb/futures.go
+++ b/bindings/go/src/fdb/futures.go
@@ -100,15 +100,18 @@ func fdb_future_block_until_ready(f *C.FDBFuture) {
 	m.Lock()
 }
 
-func (f future) BlockUntilReady() {
+func (f *future) BlockUntilReady() {
+	defer runtime.KeepAlive(f)
 	fdb_future_block_until_ready(f.ptr)
 }
 
-func (f future) IsReady() bool {
+func (f *future) IsReady() bool {
+	defer runtime.KeepAlive(f)
 	return C.fdb_future_is_ready(f.ptr) != 0
 }
 
-func (f future) Cancel() {
+func (f *future) Cancel() {
+	defer runtime.KeepAlive(f)
 	C.fdb_future_cancel(f.ptr)
 }
 
@@ -140,6 +143,8 @@ type futureByteSlice struct {
 
 func (f *futureByteSlice) Get() ([]byte, error) {
 	f.o.Do(func() {
+		defer runtime.KeepAlive(f.future)
+
 		var present C.fdb_bool_t
 		var value *C.uint8_t
 		var length C.int
@@ -195,6 +200,8 @@ type futureKey struct {
 
 func (f *futureKey) Get() (Key, error) {
 	f.o.Do(func() {
+		defer runtime.KeepAlive(f.future)
+
 		var value *C.uint8_t
 		var length C.int
 
@@ -241,7 +248,9 @@ type futureNil struct {
 	*future
 }
 
-func (f futureNil) Get() error {
+func (f *futureNil) Get() error {
+	defer runtime.KeepAlive(f.future)
+
 	f.BlockUntilReady()
 	if err := C.fdb_future_get_error(f.ptr); err != 0 {
 		return Error{int(err)}
@@ -250,7 +259,7 @@ func (f futureNil) Get() error {
 	return nil
 }
 
-func (f futureNil) MustGet() {
+func (f *futureNil) MustGet() {
 	if err := f.Get(); err != nil {
 		panic(err)
 	}
@@ -272,7 +281,9 @@ func stringRefToSlice(ptr unsafe.Pointer) []byte {
 	return C.GoBytes(src, size)
 }
 
-func (f futureKeyValueArray) Get() ([]KeyValue, bool, error) {
+func (f *futureKeyValueArray) Get() ([]KeyValue, bool, error) {
+	defer runtime.KeepAlive(f.future)
+
 	f.BlockUntilReady()
 
 	var kvs *C.FDBKeyValue
@@ -316,17 +327,20 @@ type futureInt64 struct {
 	*future
 }
 
-func (f futureInt64) Get() (int64, error) {
+func (f *futureInt64) Get() (int64, error) {
+	defer runtime.KeepAlive(f.future)
+
 	f.BlockUntilReady()
 
 	var ver C.int64_t
 	if err := C.fdb_future_get_version(f.ptr, &ver); err != 0 {
 		return 0, Error{int(err)}
 	}
+
 	return int64(ver), nil
 }
 
-func (f futureInt64) MustGet() int64 {
+func (f *futureInt64) MustGet() int64 {
 	val, err := f.Get()
 	if err != nil {
 		panic(err)
@@ -356,7 +370,9 @@ type futureStringSlice struct {
 	*future
 }
 
-func (f futureStringSlice) Get() ([]string, error) {
+func (f *futureStringSlice) Get() ([]string, error) {
+	defer runtime.KeepAlive(f.future)
+
 	f.BlockUntilReady()
 
 	var strings **C.char
@@ -375,7 +391,7 @@ func (f futureStringSlice) Get() ([]string, error) {
 	return ret, nil
 }
 
-func (f futureStringSlice) MustGet() []string {
+func (f *futureStringSlice) MustGet() []string {
 	val, err := f.Get()
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
this is based on #1 but calls keep alive only on futures